### PR TITLE
Add error check for cloud plug list in init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -152,7 +152,11 @@ def getPlugs():
     resp = httpTPlink(url, data_input)
     if resp == False:
         return []
-    deviceList = resp["result"]["deviceList"]
+    try:
+        deviceList = resp["result"]["deviceList"]
+    except:
+        cbpi.notify("TPLink Error", "Unable to read device list from cloud, check token.", type="danger",  timeout=None)
+        deviceList = []
     return deviceList
 
 @cbpi.initalizer(order=10)


### PR DESCRIPTION
If the TPLink cloud returns a message that dosent contain "result", cbpi could not be started